### PR TITLE
Improve alert detail formatting in trip.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "MBTAclient"
-version = "1.1.31"
+version = "1.1.32"
 description = "A Python client for interacting with the MBTA API"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mbtaclient/trip.py
+++ b/src/mbtaclient/trip.py
@@ -258,9 +258,15 @@ class Trip:
         if self.mbta_alerts:
             for mbta_alert in self.mbta_alerts:
                 effect = " ".join(mbta_alert.effect.split("_"))
-                short_header = mbta_alert.short_header
-                alerts_details.add(effect + ": " + short_header)
-            return alerts_details
+                short_header = mbta_alert.short_header.strip()
+                header = mbta_alert.header.strip() if hasattr(mbta_alert, "header") else ""
+                
+                # Use short_header if available, otherwise fallback to full header
+                detail = short_header if short_header else header
+                if detail:  # only add if detail is not empty
+                    alerts_details.add(f"{effect}: {detail}")
+            
+            return alerts_details if alerts_details else None
         return None
 
     def get_stop_by_type(self, stop_type: str) -> Optional[Stop]:


### PR DESCRIPTION
Strip whitespace from short_header and header, and use header if short_header is not available.