### PR TITLE
only call .replace if object exists 

### DIFF
--- a/src/mbtaclient/handlers/base_handler.py
+++ b/src/mbtaclient/handlers/base_handler.py
@@ -407,8 +407,8 @@ class MBTABaseHandler:
 
             for informed_entity in mbta_alert.informed_entities:
 
-                active_period_start = mbta_alert.active_period_start.replace(tzinfo=None)
-                active_period_end = mbta_alert.active_period_end.replace(tzinfo=None)
+                active_period_start = mbta_alert.active_period_start.replace(tzinfo=None) if mbta_alert.active_period_start else None
+                active_period_end = mbta_alert.active_period_end.replace(tzinfo=None) if mbta_alert.active_period_end else None
 
                 try:
                     if (


### PR DESCRIPTION
I came across this error in my logs using the MBTALive 2.0 HACS integration:

```bash
Unexpected error in __is_alert_relevant: 'NoneType' object has no attribute 'replace'
Traceback (most recent call last): File "/usr/local/lib/python3.14/site-packages/mbtaclient/handlers/base_handler.py",
line 411, in __is_alert_relevant active_period_end = mbta_alert.active_period_end.replace(tzinfo=None) 
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AttributeError: 'NoneType' object has no attribute 'replace'
```

this adds a simple check to only call .replace() if exists.

This may be similar to issue https://github.com/chiabre/MBTAClient/issues/49